### PR TITLE
Use 'Animated.View.propTypes' to avoid warnings.

### DIFF
--- a/TabBar.js
+++ b/TabBar.js
@@ -11,7 +11,7 @@ import Layout from './Layout';
 
 export default class TabBar extends React.Component {
   static propTypes = {
-    ...View.propTypes,
+    ...Animated.View.propTypes,
     shadowStyle: View.propTypes.style,
   };
 


### PR DESCRIPTION
The propTypes Validation must be based on `Animated.View.propTypes` instead of just `View.propTypes` 
otherwise a Warning is displayed when passing Animated values to TabBar.
